### PR TITLE
fix. 후속 리뷰 반영 및 Testing 의존성 정리

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -8,24 +8,6 @@
         "revision" : "62a10ccb29c821f5e66c5e440fd263ceddc971e3",
         "version" : "0.7.0"
       }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-testing",
-      "state" : {
-        "revision" : "395288f1d154d0e8b92823313957546ddb88106c",
-        "version" : "0.1.0"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-man/LimitLengthTextField", from: "0.7.0"),
-        .package(url: "https://github.com/swiftlang/swift-testing", from: "0.1.0")
+        .package(url: "https://github.com/swift-man/LimitLengthTextField", from: "0.7.0")
     ],
     targets: [
         .target(
@@ -29,8 +28,7 @@ let package = Package(
         .testTarget(
             name: "GoogleStyleSwiftUITests",
             dependencies: [
-                "GoogleStyleSwiftUI",
-                .product(name: "Testing", package: "swift-testing")
+                "GoogleStyleSwiftUI"
             ],
             path: "Tests/GoogleStyleSwiftUITests"
         )

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Feature
 * [x] TextField
 * [x] SecureField
-* [x] TextField - limiteCount, prompt
+* [x] TextField - limitCount, prompt
 * [x] Refactor - SecureField
 * [ ] Fix - padding()
 * [ ] Picker
@@ -23,6 +23,8 @@
 ![Image](https://drive.google.com/uc?export=view&id=1hMiMVD3qbRP6fWTKKsp4H7ASxYneAo1M)  
 
 ## TextField
+`limit` 기본값은 `100`이며, `0` 이하 값은 안전한 최소값인 `1`로 정규화됩니다.
+
 ```swift
 import SwiftUI
 

--- a/Sources/GoogleStyleSwiftUI/Private/GSErrorMessage.swift
+++ b/Sources/GoogleStyleSwiftUI/Private/GSErrorMessage.swift
@@ -8,11 +8,10 @@
 import SwiftUI
 
 struct GSErrorMessage: View {
-  @Binding
-  private var errorMessage: String
+  private let errorMessage: String
   
-  init(errorMessage: Binding<String>) {
-    self._errorMessage = errorMessage
+  init(errorMessage: String) {
+    self.errorMessage = errorMessage
   }
   
   private var errorForegroundColor: Color {
@@ -41,6 +40,6 @@ struct GoogleStyleErrorMessage_Previews: PreviewProvider {
   static var message = "이름을 입력하세요."
   
   static var previews: some View {
-    GSErrorMessage(errorMessage: $message)
+    GSErrorMessage(errorMessage: message)
   }
 }

--- a/Sources/GoogleStyleSwiftUI/Private/GSTextFieldModifier.swift
+++ b/Sources/GoogleStyleSwiftUI/Private/GSTextFieldModifier.swift
@@ -37,26 +37,33 @@ struct GSTextFieldModifier: ViewModifier {
   func body(content: Content) -> some View {
     content
       .focused(isFocused)
-      .onChange(of: isFocused.wrappedValue) { newValue in
+      .onChange(of: isFocused.wrappedValue, perform: { newValue in
         withAnimation(.easeInOut(duration: 0.15)) {
-          if newValue {
-            offsetY = .top
-          } else {
-            offsetY = text.isEmpty ? .center : .top
-          }
-          
-          configureColor(errorMessage: errorMessage, isFocused: newValue)
+          synchronizeState(isFocused: newValue,
+                           errorMessage: errorMessage)
         }
-      }
+      })
       .onChange(of: errorMessage, perform: { newValue in
         withAnimation(.easeInOut(duration: 0.15)) {
-          configureColor(errorMessage: newValue, isFocused: isFocused.wrappedValue)
+          synchronizeState(isFocused: isFocused.wrappedValue,
+                           errorMessage: newValue)
+        }
+      })
+      .onChange(of: text, perform: { _ in
+        withAnimation(.easeInOut(duration: 0.15)) {
+          synchronizeState(isFocused: isFocused.wrappedValue,
+                           errorMessage: errorMessage)
         }
       })
       .padding(EdgeInsets(top: 5,
                           leading: 15,
                           bottom: 5,
                           trailing: 15))
+  }
+
+  private func synchronizeState(isFocused: Bool, errorMessage: String) {
+    offsetY = isFocused || !text.isEmpty ? .top : .center
+    configureColor(errorMessage: errorMessage, isFocused: isFocused)
   }
   
   private func configureColor(errorMessage: String, isFocused: Bool) {

--- a/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
@@ -76,7 +76,7 @@ public struct GSSecureField: View {
       .frame(height: 45)
       
       if !errorMessage.isEmpty {
-        GSErrorMessage(errorMessage: $errorMessage)
+        GSErrorMessage(errorMessage: errorMessage)
       } else {
         if !description.isEmpty {
           GSText(description: description)

--- a/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
@@ -76,7 +76,7 @@ public struct GSTextField: View {
       .frame(height: 45)
       
       if !errorMessage.isEmpty {
-        GSErrorMessage(errorMessage: $errorMessage)
+        GSErrorMessage(errorMessage: errorMessage)
       } else {
         if !description.isEmpty {
           GSText(description: description)


### PR DESCRIPTION
## 변경 요약
- PR #10 후속 리뷰 댓글 중 실제 수정 가치가 있는 항목을 반영했습니다.
- GSTextFieldModifier가 text 바인딩 변경을 감시해 외부에서 값이 초기화/변경될 때 placeholder 위치와 색상 상태를 다시 동기화하도록 수정했습니다.
- onChange 표기를 perform: 형태로 통일해 iOS 15 지원 범위에서 API 해석이 명확하도록 정리했습니다.
- 읽기 전용 GSErrorMessage에서 불필요한 Binding<String> 의존성을 제거했습니다.
- Swift 6 내장 Testing을 사용하도록 외부 swift-testing 패키지 의존성을 제거했습니다.
- README의 limiteCount 오탈자와 limit <= 0 정규화 규칙을 문서화했습니다.

## 리뷰 댓글 판정
- 실제 수정 필요: 외부 text 변경 시 UI 상태가 동기화되지 않을 수 있다는 지적
- 실제 수정 필요: 외부 swift-testing 0.1.0 의존성이 현재 SwiftPM 테스트 러너와 충돌할 수 있다는 지적
- 실제 수정 필요: 읽기 전용 에러 메시지 뷰의 Binding 의존성 축소
- 반영 가능한 정리: onChange 표기 통일
- 후속 보류: 전체 색상 시스템/레이아웃 리팩터링은 디자인 변경 폭이 커 별도 설계 이슈로 분리하는 것이 적절

## 검증
- swift package clean
- swift test 통과
