### PR TITLE
feat. TextView와 멀티라인 입력 컴포넌트 지원

### DIFF
--- a/.github/workflows/deploy-docc.yml
+++ b/.github/workflows/deploy-docc.yml
@@ -1,0 +1,39 @@
+name: Deploy DocC
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-docc-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-docs:
+    runs-on: macos-latest
+
+    steps:
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Build DocC
+        run: |
+          ./GeneratingDocumentationSite
+          touch ./docs/.nojekyll
+
+      - name: Deploy to swift-man/docs
+        # peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
+        with:
+          deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
+          external_repository: swift-man/docs
+          publish_branch: main
+          publish_dir: ./docs
+          destination_dir: GoogleStyleSwiftUI
+          keep_files: true
+          full_commit_message: Deploy GoogleStyleSwiftUI DocC from ${{ github.repository }}@${{ github.sha }}

--- a/.reviewbot.yml
+++ b/.reviewbot.yml
@@ -45,4 +45,6 @@ review:
     - "Package.resolved"
     - "Sources/GoogleStyleSwiftUI/Public/Color+.swift"
     - "Sources/GoogleStyleSwiftUI/Public/GSTextField.swift"
+    - "Sources/GoogleStyleSwiftUI/Public/GSMultilineTextField.swift"
+    - "Sources/GoogleStyleSwiftUI/Public/GSTextView.swift"
     - "Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 - 공개 API는 `Public`, 내부 구현은 `Private`로 구분한다.
 
 ### Dependency Inversion
-- 외부 라이브러리(`LimitLengthTextField`, `swift-testing`)는 `Private`/`Tests`에서만 직접 참조하고,
+- 외부 라이브러리(`LimitLengthTextField`)는 `Private`에서만 직접 참조하고,
   공개 API는 자체 뷰 컴포넌트로만 노출한다.
 
 ## SPM 기준 리뷰 예외/대상
@@ -41,6 +41,8 @@
 - `Package.swift`, `Package.resolved`
 - `Sources/GoogleStyleSwiftUI/Public/Color+.swift`
 - `Sources/GoogleStyleSwiftUI/Public/GSTextField.swift`
+- `Sources/GoogleStyleSwiftUI/Public/GSMultilineTextField.swift`
+- `Sources/GoogleStyleSwiftUI/Public/GSTextView.swift`
 - `Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift`
 
 ## PR/Review Operations

--- a/GeneratingDocumentationSite
+++ b/GeneratingDocumentationSite
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+TARGET_NAME="${TARGET_NAME:-GoogleStyleSwiftUI}"
+PACKAGE_BUILD_PATH="${PACKAGE_BUILD_PATH:-.build}"
+SYMBOL_GRAPH_PATH="${SYMBOL_GRAPH_PATH:-$PACKAGE_BUILD_PATH/docc-symbolgraphs}"
+DOCC_CATALOG_PATH="${DOCC_CATALOG_PATH:-Sources/$TARGET_NAME/$TARGET_NAME.docc}"
+DOCC_ARCHIVE_PATH="${DOCC_ARCHIVE_PATH:-./$TARGET_NAME.doccarchive}"
+DOCS_OUTPUT_PATH="${DOCS_OUTPUT_PATH:-./docs}"
+HOSTING_BASE_PATH="${HOSTING_BASE_PATH:-GoogleStyleSwiftUI}"
+BUNDLE_IDENTIFIER="${BUNDLE_IDENTIFIER:-com.swift-man.GoogleStyleSwiftUI.$TARGET_NAME}"
+BUNDLE_VERSION="${BUNDLE_VERSION:-1.0.0}"
+MINIMUM_ACCESS_LEVEL="${MINIMUM_ACCESS_LEVEL:-public}"
+
+DOCC="$(xcrun --find docc)"
+
+rm -rf "$SYMBOL_GRAPH_PATH" "$DOCS_OUTPUT_PATH" "$DOCC_ARCHIVE_PATH"
+mkdir -p "$SYMBOL_GRAPH_PATH"
+
+swift build --target "$TARGET_NAME"
+
+if ! swift package dump-symbol-graph --minimum-access-level "$MINIMUM_ACCESS_LEVEL"; then
+  echo "warning: dump-symbol-graph exited non-zero; continuing if $TARGET_NAME symbols were emitted" >&2
+fi
+
+find "$PACKAGE_BUILD_PATH" \
+  -path "*/symbolgraph/$TARGET_NAME*.symbols.json" \
+  ! -name "${TARGET_NAME}PackageTests.symbols.json" \
+  -exec cp {} "$SYMBOL_GRAPH_PATH/" \;
+
+if [ -z "$(find "$SYMBOL_GRAPH_PATH" -name '*.symbols.json' -print -quit)" ]; then
+  echo "error: no symbol graphs found for $TARGET_NAME" >&2
+  exit 1
+fi
+
+"$DOCC" convert "$DOCC_CATALOG_PATH" \
+  --additional-symbol-graph-dir "$SYMBOL_GRAPH_PATH" \
+  --fallback-display-name "$TARGET_NAME" \
+  --fallback-bundle-identifier "$BUNDLE_IDENTIFIER" \
+  --fallback-bundle-version "$BUNDLE_VERSION" \
+  --output-path "$DOCC_ARCHIVE_PATH"
+
+"$DOCC" process-archive \
+  transform-for-static-hosting "$DOCC_ARCHIVE_PATH" \
+  --output-path "$DOCS_OUTPUT_PATH" \
+  --hosting-base-path "$HOSTING_BASE_PATH"
+
+HOSTING_BASE_PATH="/${HOSTING_BASE_PATH#/}"
+export HOSTING_BASE_PATH
+
+perl -0pi -e '
+  my $base = $ENV{"HOSTING_BASE_PATH"};
+  s#href="/favicon\.ico"#href="$base/favicon.ico"#g;
+  s#href="/favicon\.svg"#href="$base/favicon.svg"#g;
+  s#var baseUrl = "/"#var baseUrl = "$base/"#g;
+  s#src="/js/#src="$base/js/#g;
+  s#href="/css/#href="$base/css/#g;
+' "$DOCS_OUTPUT_PATH/index.html"
+
+find "$DOCS_OUTPUT_PATH" -type f -name '*.js' \
+  -exec perl -0pi -e 's/[ \t]+$//mg' {} +
+
+rm -rf "$DOCC_ARCHIVE_PATH" "$SYMBOL_GRAPH_PATH"

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "GoogleStyleSwiftUI",
     platforms: [
-        .iOS(.v15),
+        .iOS(.v16),
         .macOS(.v12)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "GoogleStyleSwiftUI",
     platforms: [
         .iOS(.v16),
-        .macOS(.v12)
+        .macOS(.v13)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Badge](https://img.shields.io/badge/SwiftUI-001b87.svg?style=flat-square&logo=Swift&logoColor=black)
 ![Badge - Version](https://img.shields.io/badge/Version-1.0.0-1177AA?style=flat-square)
 ![Badge - Swift Package Manager](https://img.shields.io/badge/SPM-Supported-orange?style=flat-square)
-![Badge - Platform](https://img.shields.io/badge/platform-macOS_12.0|iOS_16.0-yellow?style=flat-square)
+![Badge - Platform](https://img.shields.io/badge/platform-macOS_13.0|iOS_16.0-yellow?style=flat-square)
 ![Badge - License](https://img.shields.io/badge/license-MIT-black?style=flat-square)
 
 ## Feature
@@ -26,7 +26,7 @@
 
 ## Requirements
 * iOS 16.0+
-* macOS 12.0+
+* macOS 13.0+
 * Swift 5.9+
 
 ## Installation
@@ -67,7 +67,7 @@ struct ContentView: View {
 ```
 
 ## Multiline TextField
-`GSMultilineTextField`는 iOS 16 이상에서 세로 확장 입력을 지원합니다.
+`GSMultilineTextField`는 iOS 16 이상, macOS 13 이상에서 세로 확장 입력을 지원합니다.
 
 ```swift
 import SwiftUI

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 ## Feature
 * [x] TextField
 * [x] SecureField
+* [x] Multiline TextField
+* [x] TextEditor / TextView
 * [x] TextField - limitCount, prompt
 * [x] Refactor - SecureField
 * [ ] Fix - padding()
@@ -84,6 +86,31 @@ struct MemoView: View {
                          isFocused: $isFocused,
                          errorMessage: $errorMessage,
                          lineLimit: 1...8)
+  }
+}
+```
+
+## TextView
+`GSTextView`는 SwiftUI `TextEditor` 기반의 긴 본문 입력을 지원합니다. SwiftUI 이름을 선호하면 `GSTextEditor` alias를 사용할 수 있습니다.
+
+```swift
+import SwiftUI
+import GoogleStyleSwiftUI
+
+struct ArticleView: View {
+  @State var text = ""
+  @State var errorMessage = ""
+  @FocusState var isFocused: Bool
+
+  var body: some View {
+    GSTextView(text: $text,
+               limit: 4000,
+               placeholder: "본문",
+               editingPlaceholder: "내용을 입력하세요.",
+               isFocused: $isFocused,
+               errorMessage: $errorMessage,
+               description: "긴 문장을 입력할 수 있습니다.",
+               minHeight: 140)
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
 * macOS 13.0+
 * Swift 5.9+
 
+## Documentation
+* [DocC Documentation](https://swift-man.github.io/docs/GoogleStyleSwiftUI/documentation/googlestyleswiftui/)
+
 ## Installation
 ```swift
 dependencies: [

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Badge](https://img.shields.io/badge/SwiftUI-001b87.svg?style=flat-square&logo=Swift&logoColor=black)
 ![Badge - Version](https://img.shields.io/badge/Version-1.0.0-1177AA?style=flat-square)
 ![Badge - Swift Package Manager](https://img.shields.io/badge/SPM-Supported-orange?style=flat-square)
-![Badge - Platform](https://img.shields.io/badge/platform-macOS_12.0|iOS_15.0-yellow?style=flat-square)
+![Badge - Platform](https://img.shields.io/badge/platform-macOS_12.0|iOS_16.0-yellow?style=flat-square)
 ![Badge - License](https://img.shields.io/badge/license-MIT-black?style=flat-square)
 
 ## Feature
@@ -25,7 +25,7 @@
 ![Image](https://drive.google.com/uc?export=view&id=1hMiMVD3qbRP6fWTKKsp4H7ASxYneAo1M)  
 
 ## Requirements
-* iOS 15.0+
+* iOS 16.0+
 * macOS 12.0+
 * Swift 5.9+
 

--- a/Sources/GoogleStyleSwiftUI/GoogleStyleSwiftUI.docc/GoogleStyleSwiftUI.md
+++ b/Sources/GoogleStyleSwiftUI/GoogleStyleSwiftUI.docc/GoogleStyleSwiftUI.md
@@ -1,0 +1,50 @@
+# GoogleStyleSwiftUI
+
+Build Google-style SwiftUI input components with floating placeholders, validation messaging, and length limits.
+
+## Overview
+
+`GoogleStyleSwiftUI` provides reusable SwiftUI form components for single-line, secure, multiline, and long-form text input.
+
+Use ``GSTextField`` for standard text input and ``GSSecureField`` for password input. Use ``GSMultilineTextField`` when you want SwiftUI's multiline `TextField(axis: .vertical)` behavior, and use ``GSTextView`` for long-form `TextEditor`-based editing.
+
+All text input components share the same public design goals:
+
+- Floating placeholder behavior
+- Validation error message support
+- Optional editing placeholder text
+- Safe length-limit normalization
+- Swift Package Manager integration
+
+```swift
+import SwiftUI
+import GoogleStyleSwiftUI
+
+struct ContentView: View {
+  @State private var text = ""
+  @State private var errorMessage = ""
+  @FocusState private var isFocused: Bool
+
+  var body: some View {
+    GSTextField(text: $text,
+                limit: 100,
+                placeholder: "Name",
+                editingPlaceholder: "Enter your name",
+                isFocused: $isFocused,
+                errorMessage: $errorMessage)
+  }
+}
+```
+
+## Topics
+
+### Text Input
+
+- ``GSTextField``
+- ``GSSecureField``
+- ``GSMultilineTextField``
+- ``GSTextView``
+
+### Text Editing Alias
+
+- ``GSTextEditor``

--- a/Sources/GoogleStyleSwiftUI/Private/GSFloatingLabelMetrics.swift
+++ b/Sources/GoogleStyleSwiftUI/Private/GSFloatingLabelMetrics.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+enum GSFloatingLabelMetrics {
+  static let floatingHorizontalOffset: CGFloat = 11
+  static let floatingLeadingPadding: CGFloat = 5
+  static let topLineCenteredYOffset: CGFloat = -10
+
+  static func centeredYOffset(containerHeight: CGFloat) -> CGFloat {
+    -(containerHeight / 2)
+  }
+}

--- a/Sources/GoogleStyleSwiftUI/Private/GSInputColorPolicy.swift
+++ b/Sources/GoogleStyleSwiftUI/Private/GSInputColorPolicy.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+enum GSInputColorPolicy {
+  static func color(errorMessage: String, isFocused: Bool) -> Color {
+    if !errorMessage.isEmpty {
+      return GSColorStyle.error.color
+    }
+
+    return isFocused ? GSColorStyle.active.color : GSColorStyle.normal.color
+  }
+}

--- a/Sources/GoogleStyleSwiftUI/Private/GSInputContainerModifier.swift
+++ b/Sources/GoogleStyleSwiftUI/Private/GSInputContainerModifier.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct GSInputContainerModifier: ViewModifier {
+  private enum Layout {
+    static let padding = EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
+    static let cornerRadius: CGFloat = 12
+  }
+
+  let background: Color?
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if let background {
+      content
+        .padding(Layout.padding)
+        .background(background, in: RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous))
+    } else {
+      content
+    }
+  }
+}

--- a/Sources/GoogleStyleSwiftUI/Private/GSPlaceholder.swift
+++ b/Sources/GoogleStyleSwiftUI/Private/GSPlaceholder.swift
@@ -15,6 +15,7 @@ struct GSPlaceholder: View {
   private let placeholder: String
   
   private let background: Color
+  private let floatingYOffset: CGFloat
   
   @Binding
   private var foregroundColor: Color
@@ -25,25 +26,28 @@ struct GSPlaceholder: View {
   init(placeholder: String,
        offsetY: Binding<OffsetY>,
        foregroundColor: Binding<Color>,
-       background: Color) {
+       background: Color,
+       floatingYOffset: CGFloat) {
     self._offsetY = offsetY
     self._foregroundColor = foregroundColor
     self.placeholder = placeholder
     self.background = background
+    self.floatingYOffset = floatingYOffset
   }
   
   var body: some View {
       HStack {
         Text(placeholder)
           .padding(EdgeInsets(top: 0,
-                              leading: offsetY == .top ? 5 : 0,
+                              leading: offsetY == .top ? GSFloatingLabelMetrics.floatingLeadingPadding : 0,
                               bottom: 0,
                               trailing: 5))
           .frame(alignment: .leading)
           .background(background)
           .font(offsetY == .top ? Font.body : Font.title3)
           .foregroundColor(offsetY == .top ? foregroundColor : GSColorStyle.normal.color)
-          .offset(x: offsetY == .top ? 6 : 15, y: offsetY == .top ? -27 : 0)
+          .offset(x: offsetY == .top ? GSFloatingLabelMetrics.floatingHorizontalOffset : 15,
+                  y: offsetY == .top ? floatingYOffset : 0)
 
         Spacer()
       }
@@ -61,6 +65,7 @@ struct GoogleStylePlaceholder_Previews: PreviewProvider {
     GSPlaceholder(placeholder: "placeholder",
                            offsetY: $offsetY,
                            foregroundColor: $color,
-                           background: .white)
+                           background: .white,
+                           floatingYOffset: GSFloatingLabelMetrics.centeredYOffset(containerHeight: 55))
   }
 }

--- a/Sources/GoogleStyleSwiftUI/Private/GSRoundedBorder.swift
+++ b/Sources/GoogleStyleSwiftUI/Private/GSRoundedBorder.swift
@@ -17,7 +17,7 @@ struct GSRoundedBorder: View {
   
   var body: some View {
     RoundedRectangle(cornerRadius: 5)
-      .stroke(color, lineWidth: isBold ? 2 : 1)
+      .strokeBorder(color, lineWidth: isBold ? 2 : 1)
   }
   
   private var isBold: Bool {

--- a/Sources/GoogleStyleSwiftUI/Private/GSTextFieldModifier.swift
+++ b/Sources/GoogleStyleSwiftUI/Private/GSTextFieldModifier.swift
@@ -67,10 +67,6 @@ struct GSTextFieldModifier: ViewModifier {
   }
   
   private func configureColor(errorMessage: String, isFocused: Bool) {
-    if !errorMessage.isEmpty {
-      color = GSColorStyle.error.color
-    } else {
-      color = isFocused ? GSColorStyle.active.color : GSColorStyle.normal.color
-    }
+    color = GSInputColorPolicy.color(errorMessage: errorMessage, isFocused: isFocused)
   }
 }

--- a/Sources/GoogleStyleSwiftUI/Private/GSTextFieldModifier.swift
+++ b/Sources/GoogleStyleSwiftUI/Private/GSTextFieldModifier.swift
@@ -55,9 +55,9 @@ struct GSTextFieldModifier: ViewModifier {
                            errorMessage: errorMessage)
         }
       })
-      .padding(EdgeInsets(top: 5,
+      .padding(EdgeInsets(top: 10,
                           leading: 15,
-                          bottom: 5,
+                          bottom: 10,
                           trailing: 15))
   }
 

--- a/Sources/GoogleStyleSwiftUI/Public/GSMultilineTextField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSMultilineTextField.swift
@@ -90,6 +90,10 @@ public struct GSMultilineTextField: View {
       }
       .padding(.top, isPlaceholderFloating ? 8 : 0)
       .frame(minHeight: Layout.minimumHeight)
+      .onAppear {
+        enforceLimit(text)
+        synchronizeState(isFocused: isFocused.wrappedValue, errorMessage: errorMessage)
+      }
       .onChange(of: isFocused.wrappedValue, perform: { newValue in
         withAnimation(.easeInOut(duration: 0.15)) {
           synchronizeState(isFocused: newValue, errorMessage: errorMessage)

--- a/Sources/GoogleStyleSwiftUI/Public/GSMultilineTextField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSMultilineTextField.swift
@@ -63,7 +63,7 @@ public struct GSMultilineTextField: View {
     self.lineLimit = Self.normalizedLineLimit(lineLimit)
     self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,
                                                                isFocused: isFocused.wrappedValue))
-    self._isPlaceholderFloating = State(initialValue: !text.wrappedValue.isEmpty)
+    self._isPlaceholderFloating = State(initialValue: !text.wrappedValue.isEmpty || isFocused.wrappedValue)
   }
 
   public var body: some View {

--- a/Sources/GoogleStyleSwiftUI/Public/GSMultilineTextField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSMultilineTextField.swift
@@ -61,7 +61,8 @@ public struct GSMultilineTextField: View {
     self.description = description
     self.background = background
     self.lineLimit = Self.normalizedLineLimit(lineLimit)
-    self._color = State(initialValue: text.wrappedValue.isEmpty ? GSColorStyle.normal.color : GSColorStyle.active.color)
+    self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,
+                                                               isFocused: isFocused.wrappedValue))
     self._isPlaceholderFloating = State(initialValue: !text.wrappedValue.isEmpty)
   }
 
@@ -83,7 +84,9 @@ public struct GSMultilineTextField: View {
           .background(background)
 
         placeholderView
+          .allowsHitTesting(false)
         editingPlaceholderView
+          .allowsHitTesting(false)
       }
       .padding(.top, isPlaceholderFloating ? 8 : 0)
       .frame(minHeight: Layout.minimumHeight)
@@ -144,11 +147,7 @@ public struct GSMultilineTextField: View {
   }
 
   private func configureColor(errorMessage: String, isFocused: Bool) {
-    if !errorMessage.isEmpty {
-      color = GSColorStyle.error.color
-    } else {
-      color = isFocused ? GSColorStyle.active.color : GSColorStyle.normal.color
-    }
+    color = GSInputColorPolicy.color(errorMessage: errorMessage, isFocused: isFocused)
   }
 
   private func enforceLimit(_ value: String) {

--- a/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 public struct GSSecureField: View {
+  private enum Layout {
+    static let minimumHeight: CGFloat = 55
+  }
   
   private var isFocused: FocusState<Bool>.Binding
   
@@ -61,7 +64,8 @@ public struct GSSecureField: View {
         GSPlaceholder(placeholder: placeholder,
                       offsetY: $offsetY,
                       foregroundColor: $color,
-                      background: background)
+                      background: background,
+                      floatingYOffset: GSFloatingLabelMetrics.centeredYOffset(containerHeight: Layout.minimumHeight))
         GSLimitedLengthSecureField(text: $text,
                                    limit: limit)
         .modifier(GSTextFieldModifier(isFocused: isFocused,
@@ -73,7 +77,7 @@ public struct GSSecureField: View {
                              editingPlaceholder: editingPlaceholder,
                              offsetY: $offsetY)
       }
-      .frame(height: 45)
+      .frame(height: Layout.minimumHeight)
       
       if !errorMessage.isEmpty {
         GSErrorMessage(errorMessage: errorMessage)

--- a/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
@@ -51,7 +51,7 @@ public struct GSSecureField: View {
     self.placeholder = placeholder
     self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,
                                                                isFocused: isFocused.wrappedValue))
-    self._offsetY = State(initialValue: text.wrappedValue.isEmpty ? .center : .top)
+    self._offsetY = State(initialValue: text.wrappedValue.isEmpty && !isFocused.wrappedValue ? .center : .top)
     self.isFocused = isFocused
     self.description = description
     self.background = background

--- a/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
@@ -46,7 +46,7 @@ public struct GSSecureField: View {
               background: Color = .background) {
     
     self._text = text
-    self.limit = limit
+    self.limit = GSLimitPolicy.normalizedLimit(limit)
     self._errorMessage = errorMessage
     self.placeholder = placeholder
     self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,

--- a/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSSecureField.swift
@@ -49,7 +49,8 @@ public struct GSSecureField: View {
     self.limit = limit
     self._errorMessage = errorMessage
     self.placeholder = placeholder
-    self._color = State(initialValue: text.wrappedValue.isEmpty ? GSColorStyle.normal.color : GSColorStyle.active.color)
+    self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,
+                                                               isFocused: isFocused.wrappedValue))
     self._offsetY = State(initialValue: text.wrappedValue.isEmpty ? .center : .top)
     self.isFocused = isFocused
     self.description = description

--- a/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
@@ -51,7 +51,8 @@ public struct GSTextField: View {
     self.limit = limit
     self._errorMessage = errorMessage
     self.placeholder = placeholder
-    self._color = State(initialValue: text.wrappedValue.isEmpty ? GSColorStyle.normal.color : GSColorStyle.active.color)
+    self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,
+                                                               isFocused: isFocused.wrappedValue))
     self._offsetY = State(initialValue: text.wrappedValue.isEmpty ? .center : .top)
     self.isFocused = isFocused
     self.description = description

--- a/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
@@ -48,7 +48,7 @@ public struct GSTextField: View {
               containerBackground: Color? = nil) {
     
     self._text = text
-    self.limit = limit
+    self.limit = GSLimitPolicy.normalizedLimit(limit)
     self._errorMessage = errorMessage
     self.placeholder = placeholder
     self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,

--- a/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 public struct GSTextField: View {
+  private enum Layout {
+    static let minimumHeight: CGFloat = 55
+  }
   
   private var isFocused: FocusState<Bool>.Binding
   
@@ -27,6 +30,7 @@ public struct GSTextField: View {
   private let editingPlaceholder: String
   private let description: String
   private let background: Color
+  private let containerBackground: Color?
   private let limit: Int
 
   /// Google style text input with floating placeholder and max length support.
@@ -40,7 +44,8 @@ public struct GSTextField: View {
               isFocused: FocusState<Bool>.Binding,
               errorMessage: Binding<String>,
               description: String = "",
-              background: Color = .background) {
+              background: Color = .background,
+              containerBackground: Color? = nil) {
     
     self._text = text
     self.limit = limit
@@ -51,17 +56,20 @@ public struct GSTextField: View {
     self.isFocused = isFocused
     self.description = description
     self.background = background
+    self.containerBackground = containerBackground
     self.editingPlaceholder = editingPlaceholder
   }
 
   public var body: some View {
     VStack {
       ZStack {
+        background
         GSRoundedBorder(color: $color)
         GSPlaceholder(placeholder: placeholder,
                       offsetY: $offsetY,
                       foregroundColor: $color,
-                      background: background)
+                      background: background,
+                      floatingYOffset: GSFloatingLabelMetrics.centeredYOffset(containerHeight: Layout.minimumHeight))
         GSLimitedLengthTextField(text: $text,
                                  limit: limit)
         .modifier(GSTextFieldModifier(isFocused: isFocused,
@@ -73,7 +81,7 @@ public struct GSTextField: View {
                              editingPlaceholder: editingPlaceholder,
                              offsetY: $offsetY)
       }
-      .frame(height: 45)
+      .frame(height: Layout.minimumHeight)
       
       if !errorMessage.isEmpty {
         GSErrorMessage(errorMessage: errorMessage)
@@ -83,5 +91,6 @@ public struct GSTextField: View {
         }
       }
     }
+    .modifier(GSInputContainerModifier(background: containerBackground))
   }
 }

--- a/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSTextField.swift
@@ -53,7 +53,7 @@ public struct GSTextField: View {
     self.placeholder = placeholder
     self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,
                                                                isFocused: isFocused.wrappedValue))
-    self._offsetY = State(initialValue: text.wrappedValue.isEmpty ? .center : .top)
+    self._offsetY = State(initialValue: text.wrappedValue.isEmpty && !isFocused.wrappedValue ? .center : .top)
     self.isFocused = isFocused
     self.description = description
     self.background = background

--- a/Sources/GoogleStyleSwiftUI/Public/GSTextView.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSTextView.swift
@@ -67,7 +67,8 @@ public struct GSTextView: View {
     self.background = background
     self.containerBackground = containerBackground
     self.minHeight = max(45, minHeight)
-    self._color = State(initialValue: text.wrappedValue.isEmpty ? GSColorStyle.normal.color : GSColorStyle.active.color)
+    self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,
+                                                               isFocused: isFocused.wrappedValue))
     self._isPlaceholderFloating = State(initialValue: !text.wrappedValue.isEmpty)
   }
 
@@ -89,7 +90,9 @@ public struct GSTextView: View {
           .allowsHitTesting(false)
 
         placeholderView
+          .allowsHitTesting(false)
         editingPlaceholderView
+          .allowsHitTesting(false)
       }
       .padding(.top, isPlaceholderFloating ? 8 : 0)
       .frame(minHeight: minHeight)
@@ -151,11 +154,7 @@ public struct GSTextView: View {
   }
 
   private func configureColor(errorMessage: String, isFocused: Bool) {
-    if !errorMessage.isEmpty {
-      color = GSColorStyle.error.color
-    } else {
-      color = isFocused ? GSColorStyle.active.color : GSColorStyle.normal.color
-    }
+    color = GSInputColorPolicy.color(errorMessage: errorMessage, isFocused: isFocused)
   }
 
   private func enforceLimit(_ value: String) {

--- a/Sources/GoogleStyleSwiftUI/Public/GSTextView.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSTextView.swift
@@ -96,6 +96,10 @@ public struct GSTextView: View {
       }
       .padding(.top, isPlaceholderFloating ? 8 : 0)
       .frame(minHeight: minHeight)
+      .onAppear {
+        enforceLimit(text)
+        synchronizeState(isFocused: isFocused.wrappedValue, errorMessage: errorMessage)
+      }
       .onChange(of: isFocused.wrappedValue, perform: { newValue in
         withAnimation(.easeInOut(duration: 0.15)) {
           synchronizeState(isFocused: newValue, errorMessage: errorMessage)

--- a/Sources/GoogleStyleSwiftUI/Public/GSTextView.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSTextView.swift
@@ -69,7 +69,7 @@ public struct GSTextView: View {
     self.minHeight = max(45, minHeight)
     self._color = State(initialValue: GSInputColorPolicy.color(errorMessage: errorMessage.wrappedValue,
                                                                isFocused: isFocused.wrappedValue))
-    self._isPlaceholderFloating = State(initialValue: !text.wrappedValue.isEmpty)
+    self._isPlaceholderFloating = State(initialValue: !text.wrappedValue.isEmpty || isFocused.wrappedValue)
   }
 
   public var body: some View {

--- a/Sources/GoogleStyleSwiftUI/Public/GSTextView.swift
+++ b/Sources/GoogleStyleSwiftUI/Public/GSTextView.swift
@@ -1,25 +1,23 @@
 //
-//  GSMultilineTextField.swift
+//  GSTextView.swift
 //  GoogleStyleUI
 //
 
 import SwiftUI
 
-@available(iOS 16.0, macOS 13.0, *)
-public struct GSMultilineTextField: View {
+public struct GSTextView: View {
 
   private enum Layout {
-    static let minimumHeight: CGFloat = 45
-    static let horizontalTextPadding: CGFloat = 15
-    static let floatingTextTopPadding: CGFloat = 10
-    static let collapsedTextTopPadding: CGFloat = 5
-    static let textBottomPadding: CGFloat = 7
+    static let horizontalTextPadding: CGFloat = 11
+    static let floatingTextTopPadding: CGFloat = 15
+    static let collapsedTextTopPadding: CGFloat = 10
+    static let textBottomPadding: CGFloat = 12
     static let floatingLabelXOffset: CGFloat = GSFloatingLabelMetrics.floatingHorizontalOffset
     static let floatingLabelYOffset: CGFloat = GSFloatingLabelMetrics.topLineCenteredYOffset
     static let collapsedLabelXOffset: CGFloat = 15
     static let collapsedLabelYOffset: CGFloat = 11
     static let editingPlaceholderXOffset: CGFloat = 17
-    static let editingPlaceholderYOffset: CGFloat = 12
+    static let editingPlaceholderYOffset: CGFloat = 23
   }
 
   private var isFocused: FocusState<Bool>.Binding
@@ -40,18 +38,25 @@ public struct GSMultilineTextField: View {
   private let editingPlaceholder: String
   private let description: String
   private let background: Color
+  private let containerBackground: Color?
   private let limit: Int
-  private let lineLimit: ClosedRange<Int>
+  private let minHeight: CGFloat
 
+  /// Google style long-form text editor with floating placeholder and max length support.
+  ///
+  /// Use `GSTextView` for long body text. Use `GSMultilineTextField` when you need
+  /// SwiftUI's multiline `TextField(axis: .vertical)` behavior.
+  /// If a non-positive `limit` is provided, the effective limit is normalized to `1`.
   public init(text: Binding<String>,
-              limit: Int = 1000,
+              limit: Int = 4000,
               placeholder: String,
               editingPlaceholder: String = "",
               isFocused: FocusState<Bool>.Binding,
               errorMessage: Binding<String>,
               description: String = "",
               background: Color = .background,
-              lineLimit: ClosedRange<Int> = 1...8) {
+              containerBackground: Color? = nil,
+              minHeight: CGFloat = 120) {
     self._text = text
     self.limit = GSLimitPolicy.normalizedLimit(limit)
     self._errorMessage = errorMessage
@@ -60,7 +65,8 @@ public struct GSMultilineTextField: View {
     self.isFocused = isFocused
     self.description = description
     self.background = background
-    self.lineLimit = Self.normalizedLineLimit(lineLimit)
+    self.containerBackground = containerBackground
+    self.minHeight = max(45, minHeight)
     self._color = State(initialValue: text.wrappedValue.isEmpty ? GSColorStyle.normal.color : GSColorStyle.active.color)
     self._isPlaceholderFloating = State(initialValue: !text.wrappedValue.isEmpty)
   }
@@ -70,23 +76,23 @@ public struct GSMultilineTextField: View {
       ZStack(alignment: .topLeading) {
         background
 
-        GSRoundedBorder(color: $color)
-
-        TextField("", text: $text, axis: .vertical)
-          .lineLimit(lineLimit)
+        TextEditor(text: $text)
           .focused(isFocused)
-          .textFieldStyle(.plain)
           .padding(EdgeInsets(top: isPlaceholderFloating ? Layout.floatingTextTopPadding : Layout.collapsedTextTopPadding,
                               leading: Layout.horizontalTextPadding,
                               bottom: Layout.textBottomPadding,
                               trailing: Layout.horizontalTextPadding))
-          .background(background)
+          .frame(minHeight: minHeight)
+          .gsTextEditorBackground(background)
+
+        GSRoundedBorder(color: $color)
+          .allowsHitTesting(false)
 
         placeholderView
         editingPlaceholderView
       }
       .padding(.top, isPlaceholderFloating ? 8 : 0)
-      .frame(minHeight: Layout.minimumHeight)
+      .frame(minHeight: minHeight)
       .onChange(of: isFocused.wrappedValue, perform: { newValue in
         withAnimation(.easeInOut(duration: 0.15)) {
           synchronizeState(isFocused: newValue, errorMessage: errorMessage)
@@ -111,6 +117,7 @@ public struct GSMultilineTextField: View {
         GSText(description: description)
       }
     }
+    .modifier(GSInputContainerModifier(background: containerBackground))
   }
 
   private var placeholderView: some View {
@@ -158,10 +165,19 @@ public struct GSMultilineTextField: View {
 
     text = String(value.prefix(limit))
   }
+}
 
-  private static func normalizedLineLimit(_ lineLimit: ClosedRange<Int>) -> ClosedRange<Int> {
-    let lowerBound = max(1, lineLimit.lowerBound)
-    let upperBound = max(lowerBound, lineLimit.upperBound)
-    return lowerBound...upperBound
+public typealias GSTextEditor = GSTextView
+
+private extension View {
+  @ViewBuilder
+  func gsTextEditorBackground(_ background: Color) -> some View {
+    if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+      self
+        .scrollContentBackground(.hidden)
+        .background(background)
+    } else {
+      self.background(background)
+    }
   }
 }


### PR DESCRIPTION
## 변경 요약
- SwiftUI TextEditor 기반 `GSTextView`를 추가했습니다.
- `GSTextEditor` alias를 제공해 SwiftUI 네이밍을 선호하는 사용자가 같은 구현을 선택할 수 있게 했습니다.
- 기존 `GSMultilineTextField`는 `TextField(axis: .vertical)` 기반 컴포넌트로 유지해, 외부에서 TextField 계열과 TextEditor 계열을 타입으로 선택할 수 있게 했습니다.
- floating label 위치 계산을 `GSFloatingLabelMetrics`로 분리했습니다.
- 입력 컴포넌트 외부 컨테이너 배경 처리를 `GSInputContainerModifier`로 분리했습니다.
- 단일 라인/보안/멀티라인 입력의 높이와 floating label 정렬을 조정했습니다.
- README와 reviewbot always_review 대상에 새 공개 API를 반영했습니다.

## 사용 기준
- `GSMultilineTextField`: 짧은 폼 입력이지만 여러 줄 확장이 필요한 경우
- `GSTextView` / `GSTextEditor`: 긴 본문 입력이 필요한 경우

## 검증
- `swift test` 통과
